### PR TITLE
Include low-fidelity actual test duration in DriverResult

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
         <dependency>
             <groupId>com.github.loadtest4j</groupId>
             <artifactId>loadtest4j</artifactId>
-            <version>0.8.1</version>
+            <version>0.9.0</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/src/main/java/com/github/loadtest4j/drivers/wrk/WrkDuration.java
+++ b/src/main/java/com/github/loadtest4j/drivers/wrk/WrkDuration.java
@@ -1,0 +1,16 @@
+package com.github.loadtest4j.drivers.wrk;
+
+import java.time.Duration;
+
+class WrkDuration {
+    private WrkDuration() {}
+
+    static Duration parse(String text) {
+        if (text.startsWith("PT")) {
+            return Duration.parse(text);
+        } else {
+            final String formattedText = String.format("PT%s", text);
+            return Duration.parse(formattedText);
+        }
+    }
+}

--- a/src/main/java/com/github/loadtest4j/drivers/wrk/WrkDuration.java
+++ b/src/main/java/com/github/loadtest4j/drivers/wrk/WrkDuration.java
@@ -5,7 +5,7 @@ import java.time.Duration;
 class WrkDuration {
     private WrkDuration() {}
 
-    static Duration parse(String text) {
+    protected static Duration parse(String text) {
         if (text.startsWith("PT")) {
             return Duration.parse(text);
         } else {

--- a/src/main/java/com/github/loadtest4j/drivers/wrk/WrkResult.java
+++ b/src/main/java/com/github/loadtest4j/drivers/wrk/WrkResult.java
@@ -2,17 +2,20 @@ package com.github.loadtest4j.drivers.wrk;
 
 import com.github.loadtest4j.loadtest4j.DriverResult;
 
+import java.time.Duration;
 import java.util.Optional;
 
 class WrkResult implements DriverResult {
 
     private final long ok;
     private final long ko;
+    private final Duration actualDuration;
     private final String reportUrl;
 
-    WrkResult(long ok, long ko, String reportUrl) {
+    WrkResult(long ok, long ko, Duration actualDuration, String reportUrl) {
         this.ok = ok;
         this.ko = ko;
+        this.actualDuration = actualDuration;
         this.reportUrl = reportUrl;
     }
 
@@ -24,6 +27,11 @@ class WrkResult implements DriverResult {
     @Override
     public long getKo() {
         return ko;
+    }
+
+    @Override
+    public Duration getActualDuration() {
+        return actualDuration;
     }
 
     @Override

--- a/src/test/java/com/github/loadtest4j/drivers/wrk/WrkDurationTest.java
+++ b/src/test/java/com/github/loadtest4j/drivers/wrk/WrkDurationTest.java
@@ -1,0 +1,26 @@
+package com.github.loadtest4j.drivers.wrk;
+
+import com.github.loadtest4j.drivers.wrk.junit.UnitTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.time.Duration;
+
+import static org.junit.Assert.assertEquals;
+
+@Category(UnitTest.class)
+public class WrkDurationTest {
+    @Test
+    public void testParseWithoutPrefix() {
+        final Duration duration = WrkDuration.parse("30.11s");
+
+        assertEquals(Duration.ofMillis(30110), duration);
+    }
+
+    @Test
+    public void testParseWithPrefix() {
+        final Duration duration = WrkDuration.parse("PT30.11s");
+
+        assertEquals(Duration.ofMillis(30110), duration);
+    }
+}

--- a/src/test/java/com/github/loadtest4j/drivers/wrk/WrkTest.java
+++ b/src/test/java/com/github/loadtest4j/drivers/wrk/WrkTest.java
@@ -32,6 +32,8 @@ import static org.junit.Assert.fail;
 @Category(IntegrationTest.class)
 public class WrkTest {
 
+    private static final Duration EXPECTED_DURATION = Duration.ofSeconds(1);
+
     private StubServer httpServer;
 
     static {
@@ -58,7 +60,7 @@ public class WrkTest {
 
     private Driver sut() {
         final String executable = "wrk";
-        return new Wrk(1, Duration.ofSeconds(1), executable, 1, getServiceUrl());
+        return new Wrk(1, EXPECTED_DURATION, executable, 1, getServiceUrl());
     }
 
     @Test
@@ -75,6 +77,7 @@ public class WrkTest {
         // Then
         assertTrue(result.getOk() > 0);
         assertEquals(0, result.getKo());
+        assertTrue(result.getActualDuration().toMillis() >= EXPECTED_DURATION.toMillis());
         final Optional<String> reportUrl = result.getReportUrl();
         assertTrue(reportUrl.isPresent());
         assertTrue(reportUrl.get().startsWith("file:///"));


### PR DESCRIPTION
Use loadtest4j 0.9.0 to achieve this