### PR TITLE
Switch CI build to Linux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,5 +9,14 @@ addons:
     packages:
     - libssl-dev
 
+env:
+- WRK_PATH=.wrk
+
+cache:
+  directories:
+  - .wrk
+
 before_install:
-- DIR=$(mktemp -d) && git clone https://github.com/wg/wrk.git $DIR && make -C $DIR && export PATH=$PATH:$DIR
+- test -d $WRK_PATH || git clone https://github.com/wg/wrk.git $WRK_PATH
+- test -f $WRK_PATH/wrk || make -C $WRK_PATH
+- export PATH=$PATH:$WRK_PATH

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,6 @@ cache:
   - .wrk
 
 before_install:
-- test -d $WRK_PATH || git clone https://github.com/wg/wrk.git $WRK_PATH
+- test -d $WRK_PATH/.git || git clone https://github.com/wg/wrk.git $WRK_PATH
 - test -f $WRK_PATH/wrk || make -C $WRK_PATH
 - export PATH=$PATH:$WRK_PATH

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,10 @@
 language: java
 
-os: osx
+jdk: oraclejdk8
 
-osx_image: xcode9.2
+sudo: false
 
 before_install:
+- sh -c "$(curl -fsSL https://raw.githubusercontent.com/Linuxbrew/install/master/install.sh)"
+- brew update
 - brew install wrk

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ addons:
     - libssl-dev
 
 env:
-- WRK_PATH=.wrk
+- WRK_PATH=".wrk"
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,5 @@ sudo: false
 
 before_install:
 - sh -c "$(curl -fsSL https://raw.githubusercontent.com/Linuxbrew/install/master/install.sh)"
-- brew update
-- brew install wrk
+- ~/.linuxbrew/bin/brew update
+- ~/.linuxbrew/bin/brew install wrk

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,4 @@ addons:
     - libssl-dev
 
 before_install:
-- DIR=$(mktemp -d) && git clone https://github.com/wg/wrk.git $DIR && make -C $DIR && cp $DIR/wrk /usr/local/bin
+- DIR=$(mktemp -d) && git clone https://github.com/wg/wrk.git $DIR && make -C $DIR && export PATH=$PATH:$DIR

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,10 @@ jdk: oraclejdk8
 
 sudo: false
 
+addons:
+  apt:
+    packages:
+    - libssl-dev
+
 before_install:
-- sh -c "$(curl -fsSL https://raw.githubusercontent.com/Linuxbrew/install/master/install.sh)"
-- ~/.linuxbrew/bin/brew update
-- ~/.linuxbrew/bin/brew install wrk
+- DIR=$(mktemp -d) && git clone https://github.com/wg/wrk.git $DIR && make -C $DIR && cp $DIR/wrk /usr/local/bin

--- a/README.md
+++ b/README.md
@@ -29,8 +29,10 @@ Then add this library:
 </dependency>
 ```
 
-Then install the `wrk` command line executable, and make it available on your `$PATH`. If you have Homebrew then just do
- `brew install wrk`.
+Then install the `wrk` command line executable, and make it available on your `$PATH`:
+
+- With Homebrew: run `brew install wrk`.
+- Without Homebrew: check out the installation method in `.travis.yml`.
 
 ## Usage
 


### PR DESCRIPTION
Because:

1. most people run their Java CI builds on Linux, not macOS.
2. With caching and containerisation the Linux build can be a bit faster.

Fixes #2 