### PR TITLE
Make 'threads' and 'connections' mandatory properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,40 +8,40 @@ The `wrk` driver for loadtest4j.
 
 ## Setup
 
-Add the [JitPack](https://jitpack.io) repository to your pom.xml:
+1. **Add the library** to your `pom.xml`:
 
-```xml
-<repositories>
-    <repository>
-        <id>jitpack.io</id>
-        <url>https://jitpack.io</url>
-    </repository>
-</repositories>
-```
+    ```xml
+     <dependency>
+         <groupId>com.github.loadtest4j</groupId>
+         <artifactId>loadtest4j-wrk</artifactId>
+         <version>[version]</version>
+     </dependency>   
+     
+    <repositories>
+        <repository>
+            <id>jitpack.io</id>
+            <url>https://jitpack.io</url>
+        </repository>
+    </repositories>
+    ```
 
-Then add this library:
+2. **Configure the driver** in `src/test/resources/loadtest4j.properties`:
+    
+    ```properties
+    loadtest4j.driver = com.github.loadtest4j.drivers.wrk.WrkFactory
+    loadtest4j.driver.connections = 1
+    loadtest4j.driver.duration = 30
+    loadtest4j.driver.threads = 1
+    loadtest4j.driver.url = https://example.com
+    ```
 
-```xml
-<dependency>
-    <groupId>com.github.loadtest4j</groupId>
-    <artifactId>loadtest4j-wrk</artifactId>
-    <version>[git tag]</version>
-</dependency>
-```
+3. **Install the `wrk` executable**, and make it available on your `$PATH`:
 
-Then install the `wrk` command line executable, and make it available on your `$PATH`:
+    - Homebrew: run `brew install wrk`.
+    - Compile from source: check out the instructions in `.travis.yml`.
 
-- With Homebrew: run `brew install wrk`.
-- Without Homebrew: check out the installation method in `.travis.yml`.
+4. **Write your load tests** using the standard [LoadTester API](https://github.com/loadtest4j/loadtest4j).
 
-## Usage
 
-Add the file `loadtest4j.properties` to your `src/test/resources` directory and configure the load test driver:
 
-```
-loadtest4j.driver = com.github.loadtest4j.drivers.wrk.WrkFactory
-loadtest4j.driver.duration = 30
-loadtest4j.driver.url = https://example.com
-```
 
-Then write your load tests in Java using the standard `LoadTester` API.

--- a/src/main/java/com/github/loadtest4j/drivers/wrk/WrkFactory.java
+++ b/src/main/java/com/github/loadtest4j/drivers/wrk/WrkFactory.java
@@ -10,7 +10,7 @@ public class WrkFactory implements DriverFactory {
 
     @Override
     public Set<String> getMandatoryProperties() {
-        return setOf("duration", "url");
+        return setOf("connections", "duration", "threads", "url");
     }
 
     /**
@@ -18,21 +18,21 @@ public class WrkFactory implements DriverFactory {
      *
      * Mandatory properties:
      *
+     * - `connections`
      * - `duration`
+     * - `threads`
      * - `url`
      *
      * Optional properties:
      *
-     * - `connections` (defaults to 1)
      * - `executable` (defaults to `wrk`, and is located using the PATH)
-     * - `threads` (defaults to 1)
      */
     @Override
     public Driver create(Map<String, String> properties) {
         final Duration duration = Duration.ofSeconds(Long.parseLong(properties.get("duration")));
-        final int connections = Integer.parseInt(properties.getOrDefault("connections", "1"));
+        final int connections = Integer.parseInt(properties.get("connections"));
         final String executable = properties.getOrDefault("executable", "wrk");
-        final int threads = Integer.parseInt(properties.getOrDefault("threads", "1"));
+        final int threads = Integer.parseInt(properties.get("threads"));
         final String url = properties.get("url");
 
         return new Wrk(connections, duration, executable, threads, url);
@@ -40,7 +40,7 @@ public class WrkFactory implements DriverFactory {
 
     private static Set<String> setOf(String... values) {
         // This utility method can be replaced when Java 9+ is more widely adopted
-        final Set<String> internalSet = new HashSet<>(Arrays.asList(values));
+        final Set<String> internalSet = new LinkedHashSet<>(Arrays.asList(values));
         return Collections.unmodifiableSet(internalSet);
     }
 }

--- a/src/test/java/com/github/loadtest4j/drivers/wrk/WrkFactoryTest.java
+++ b/src/test/java/com/github/loadtest4j/drivers/wrk/WrkFactoryTest.java
@@ -30,7 +30,7 @@ public class WrkFactoryTest {
 
         final Set<String> mandatoryProperties = sut.getMandatoryProperties();
 
-        assertThat(mandatoryProperties).containsExactly("duration", "url");
+        assertThat(mandatoryProperties).containsExactly("connections", "duration", "threads", "url");
     }
 
     @Test(expected = UnsupportedOperationException.class)
@@ -45,7 +45,9 @@ public class WrkFactoryTest {
         final DriverFactory sut = sut();
 
         final Map<String, String> properties = new HashMap<>();
+        properties.put("connections", "1");
         properties.put("duration", "2");
+        properties.put("threads", "1");
         properties.put("url", "https://example.com");
 
         final Driver driver = sut.create(properties);


### PR DESCRIPTION
New users are unlikely to discover the optional properties, so make everything a mandatory property apart from the 'executable'.