### PR TITLE
Read wrk result directly from STDOUT/ERR

### DIFF
--- a/src/main/java/org/loadtest4j/drivers/wrk/WrkResult.java
+++ b/src/main/java/org/loadtest4j/drivers/wrk/WrkResult.java
@@ -12,14 +12,12 @@ class WrkResult implements DriverResult {
     private final long ko;
     private final Duration actualDuration;
     private final DriverResponseTime responseTime;
-    private final String reportUrl;
 
-    WrkResult(long ok, long ko, Duration actualDuration, DriverResponseTime responseTime, String reportUrl) {
+    WrkResult(long ok, long ko, Duration actualDuration, DriverResponseTime responseTime) {
         this.ok = ok;
         this.ko = ko;
         this.actualDuration = actualDuration;
         this.responseTime = responseTime;
-        this.reportUrl = reportUrl;
     }
 
     @Override
@@ -44,6 +42,6 @@ class WrkResult implements DriverResult {
 
     @Override
     public Optional<String> getReportUrl() {
-        return Optional.of(reportUrl);
+        return Optional.empty();
     }
 }

--- a/src/main/java/org/loadtest4j/drivers/wrk/utils/FileUtils.java
+++ b/src/main/java/org/loadtest4j/drivers/wrk/utils/FileUtils.java
@@ -8,7 +8,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 
-public class TempFile {
+public class FileUtils {
     public static Path createTempFile(String prefix, String suffix) {
         try {
             return Files.createTempFile(prefix, suffix);

--- a/src/main/java/org/loadtest4j/drivers/wrk/utils/Json.java
+++ b/src/main/java/org/loadtest4j/drivers/wrk/utils/Json.java
@@ -5,7 +5,7 @@ import org.loadtest4j.LoadTesterException;
 
 import java.io.File;
 import java.io.IOException;
-import java.net.URL;
+import java.io.Reader;
 
 public class Json {
 
@@ -19,7 +19,7 @@ public class Json {
         }
     }
 
-    public static <T> T parse(URL src, Class<T> valueType) {
+    public static <T> T parse(Reader src, Class<T> valueType) {
         try {
             return MAPPER.readValue(src, valueType);
         } catch (IOException e) {

--- a/src/test/java/org/loadtest4j/drivers/wrk/WrkTest.java
+++ b/src/test/java/org/loadtest4j/drivers/wrk/WrkTest.java
@@ -75,7 +75,7 @@ public class WrkTest {
         DriverResultAssert.assertThat(result)
                 .hasOkGreaterThan(0)
                 .hasKo(0)
-                .hasReportUrlWithScheme("file")
+                .hasNoReportUrl()
                 .hasActualDurationGreaterThan(EXPECTED_DURATION)
                 .hasMaxResponseTimeGreaterThan(Duration.ZERO);
     }

--- a/src/test/java/org/loadtest4j/drivers/wrk/junit/DriverResultAssert.java
+++ b/src/test/java/org/loadtest4j/drivers/wrk/junit/DriverResultAssert.java
@@ -76,16 +76,12 @@ public class DriverResultAssert extends AbstractAssert<DriverResultAssert, Drive
         return this;
     }
 
-    public DriverResultAssert hasReportUrlWithScheme(String scheme) {
+    public DriverResultAssert hasNoReportUrl() {
         isNotNull();
 
-        if (!actual.getReportUrl().isPresent()) {
-            failWithMessage("Expected report URL to be present but was absent");
-        }
-
-        if (!actual.getReportUrl().get().startsWith(scheme)) {
-            failWithMessage("Expected report URL scheme to be <%s> but it was not", scheme);
-        }
+        actual.getReportUrl().ifPresent(url -> {
+            failWithMessage("Expected report URL to be absent but was <%s>", url);
+        });
 
         return this;
     }

--- a/src/test/java/org/loadtest4j/drivers/wrk/utils/FileUtilsTest.java
+++ b/src/test/java/org/loadtest4j/drivers/wrk/utils/FileUtilsTest.java
@@ -12,10 +12,10 @@ import java.nio.file.Path;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @Category(IntegrationTest.class)
-public class TempFileTest {
+public class FileUtilsTest {
 
     private static InputStream file(String name) {
-        return TempFileTest.class.getClassLoader().getResourceAsStream("fixtures/files/" + name);
+        return FileUtilsTest.class.getClassLoader().getResourceAsStream("fixtures/files/" + name);
     }
 
     private static InputStream closed() {
@@ -30,26 +30,26 @@ public class TempFileTest {
 
     @Test
     public void testCreate() {
-        final Path path = TempFile.createTempFile("foo", ".json");
+        final Path path = FileUtils.createTempFile("foo", ".json");
 
         assertThat(path.toFile()).exists();
     }
 
     @Test
     public void testCopy() {
-        final Path path = TempFile.createTempFile("foo", ".json");
+        final Path path = FileUtils.createTempFile("foo", ".json");
 
-        TempFile.copy(file("foo.json"), path);
+        FileUtils.copy(file("foo.json"), path);
 
         assertThat(path.toFile()).hasContent("{}");
     }
 
     @Test(expected = LoadTesterException.class)
     public void testCopyError() {
-        final Path path = TempFile.createTempFile("foo", ".json");
+        final Path path = FileUtils.createTempFile("foo", ".json");
 
         final InputStream closed = closed();
 
-        TempFile.copy(closed, path);
+        FileUtils.copy(closed, path);
     }
 }

--- a/src/test/java/org/loadtest4j/drivers/wrk/utils/JsonTest.java
+++ b/src/test/java/org/loadtest4j/drivers/wrk/utils/JsonTest.java
@@ -7,16 +7,18 @@ import org.loadtest4j.LoadTesterException;
 import org.loadtest4j.drivers.wrk.junit.IntegrationTest;
 
 import java.io.File;
-import java.net.MalformedURLException;
-import java.net.URL;
+import java.io.FileReader;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.nio.charset.StandardCharsets;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 @Category(IntegrationTest.class)
 public class JsonTest {
 
-    private static URL json(String name) {
-        return JsonTest.class.getClassLoader().getResource("fixtures/json/" + name);
+    private static Reader json(String name) {
+        return new InputStreamReader(JsonTest.class.getClassLoader().getResourceAsStream("fixtures/json/" + name), StandardCharsets.UTF_8);
     }
 
     public static class Foo {
@@ -25,43 +27,33 @@ public class JsonTest {
     }
 
     @Test
-    public void testRoundTrip() {
+    public void testRoundTrip() throws Exception {
         final Foo input = new Foo();
         input.a = "b";
 
-        File file = TempFile.createTempFile("foo", ".json").toFile();
+        File file = FileUtils.createTempFile("foo", ".json").toFile();
 
         Json.serialize(file, input);
 
-        final Foo output = Json.parse(toUrl(file), Foo.class);
+        final Foo output = Json.parse(new FileReader(file), Foo.class);
 
         assertThat(output.a).isEqualTo(input.a);
     }
 
     @Test(expected = LoadTesterException.class)
-    public void testParseError() {
-        final URL url = json("invalid.json");
-
-        Json.parse(url, Foo.class);
+    public void testParseError() throws Exception {
+        try (Reader reader = json("invalid.json")) {
+            Json.parse(reader, Foo.class);
+        }
     }
 
     @Test(expected = LoadTesterException.class)
     public void testSerializeError() {
         final Foo foo = new Foo();
 
-        File file = TempFile.createTempFile("foo", ".json").toFile();
+        File file = FileUtils.createTempFile("foo", ".json").toFile();
         file.setWritable(false);
 
         Json.serialize(file, foo);
-    }
-
-    private static URL toUrl(File file) {
-        final URL url;
-        try {
-            url = file.toURL();
-        } catch (MalformedURLException e) {
-            throw new RuntimeException("Should have converted from File to URL");
-        }
-        return url;
     }
 }


### PR DESCRIPTION
Parse the DriverResult directly from STDERR to avoid creating an intermediary temp file.

Fixes #37 