### PR TITLE
Use loadtest4j 0.16.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
         <dependency>
             <groupId>org.loadtest4j</groupId>
             <artifactId>loadtest4j</artifactId>
-            <version>0.15.0</version>
+            <version>0.16.0</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/src/main/java/org/loadtest4j/drivers/wrk/Wrk.java
+++ b/src/main/java/org/loadtest4j/drivers/wrk/Wrk.java
@@ -71,9 +71,6 @@ class Wrk implements Driver {
         final Path luaScript = createLuaScript();
         final Path luaOutput = FileUtils.createTempFile("loadtest4j-output", ".json");
 
-        // FIXME remove
-        System.out.println(luaOutput.toString());
-
         final List<String> arguments = new ArgumentBuilder()
                 .addNamedArgument("--connections", valueOf(connections))
                 .addNamedArgument("--duration", String.format("%ds", duration.getSeconds()))

--- a/src/main/java/org/loadtest4j/drivers/wrk/Wrk.java
+++ b/src/main/java/org/loadtest4j/drivers/wrk/Wrk.java
@@ -81,6 +81,13 @@ class Wrk implements Driver {
 
         final Process process = new Shell().start(command);
 
+        final DriverResult driverResult;
+        try (Reader reader = new InputStreamReader(process.getStderr(), StandardCharsets.UTF_8)) {
+            driverResult = toDriverResult(reader);
+        } catch (IOException e) {
+            throw new LoadTesterException(e);
+        }
+
         final int exitStatus = process.waitFor();
 
         if (exitStatus != 0) {
@@ -88,11 +95,7 @@ class Wrk implements Driver {
             throw new LoadTesterException("Wrk error:\n\n" + error);
         }
 
-        try (Reader reader = new InputStreamReader(process.getStderr(), StandardCharsets.UTF_8)) {
-            return toDriverResult(reader);
-        } catch (IOException e) {
-            throw new LoadTesterException(e);
-        }
+        return driverResult;
     }
 
     protected static DriverResult toDriverResult(Reader report) {

--- a/src/main/java/org/loadtest4j/drivers/wrk/WrkResponseTime.java
+++ b/src/main/java/org/loadtest4j/drivers/wrk/WrkResponseTime.java
@@ -24,7 +24,7 @@ class WrkResponseTime implements DriverResponseTime {
 
         final BigDecimal decimalI = BigDecimal.valueOf(i);
 
-        if (decimalI.scale() > 5) {
+        if (decimalI.scale() > DECIMAL_PLACES) {
             throw new IllegalArgumentException(String.format("The Wrk driver only supports percentile queries up to %d decimal places.", DECIMAL_PLACES));
         }
 

--- a/src/main/java/org/loadtest4j/drivers/wrk/WrkResponseTime.java
+++ b/src/main/java/org/loadtest4j/drivers/wrk/WrkResponseTime.java
@@ -17,11 +17,7 @@ class WrkResponseTime implements DriverResponseTime {
     }
 
     @Override
-    public Duration getPercentile(int i) {
-        return getDoublePercentile((double) i);
-    }
-
-    Duration getDoublePercentile(double i) {
+    public Duration getPercentile(double i) {
         if (i < 0 || i > 100) {
             throw new IllegalArgumentException("A percentile must be between 0 and 100");
         }

--- a/src/main/java/org/loadtest4j/drivers/wrk/WrkResponseTime.java
+++ b/src/main/java/org/loadtest4j/drivers/wrk/WrkResponseTime.java
@@ -8,7 +8,7 @@ import java.util.TreeMap;
 
 class WrkResponseTime implements DriverResponseTime {
 
-    private static final int DECIMAL_PLACES = 5;
+    private static final int DECIMAL_PLACES = 3;
 
     private final TreeMap<BigDecimal, Long> percentiles;
 

--- a/src/main/java/org/loadtest4j/drivers/wrk/WrkResponseTime.java
+++ b/src/main/java/org/loadtest4j/drivers/wrk/WrkResponseTime.java
@@ -2,24 +2,42 @@ package org.loadtest4j.drivers.wrk;
 
 import org.loadtest4j.driver.DriverResponseTime;
 
+import java.math.BigDecimal;
 import java.time.Duration;
-import java.util.Map;
+import java.util.TreeMap;
 
 class WrkResponseTime implements DriverResponseTime {
 
-    private final Map<Integer, Long> percentiles;
+    private static final int DECIMAL_PLACES = 5;
 
-    WrkResponseTime(Map<Integer, Long> percentiles) {
+    private final TreeMap<BigDecimal, Long> percentiles;
+
+    WrkResponseTime(TreeMap<BigDecimal, Long> percentiles) {
         this.percentiles = percentiles;
     }
 
     @Override
     public Duration getPercentile(int i) {
+        return getDoublePercentile((double) i);
+    }
+
+    Duration getDoublePercentile(double i) {
         if (i < 0 || i > 100) {
             throw new IllegalArgumentException("A percentile must be between 0 and 100");
         }
 
-        final long durationMicroseconds = percentiles.get(i);
+        final BigDecimal decimalI = BigDecimal.valueOf(i);
+
+        if (decimalI.scale() > 5) {
+            throw new IllegalArgumentException(String.format("The Wrk driver only supports percentile queries up to %d decimal places.", DECIMAL_PLACES));
+        }
+
+        final long durationMicroseconds;
+        try {
+            durationMicroseconds = percentiles.get(decimalI);
+        } catch (NullPointerException e) {
+            throw new IllegalArgumentException("The Wrk driver could not find a response time value for that percentile.");
+        }
 
         return Duration.ofNanos(durationMicroseconds * 1000);
     }

--- a/src/main/java/org/loadtest4j/drivers/wrk/WrkResult.java
+++ b/src/main/java/org/loadtest4j/drivers/wrk/WrkResult.java
@@ -4,7 +4,6 @@ import org.loadtest4j.driver.DriverResponseTime;
 import org.loadtest4j.driver.DriverResult;
 
 import java.time.Duration;
-import java.util.Optional;
 
 class WrkResult implements DriverResult {
 
@@ -38,10 +37,5 @@ class WrkResult implements DriverResult {
     @Override
     public DriverResponseTime getResponseTime() {
         return responseTime;
-    }
-
-    @Override
-    public Optional<String> getReportUrl() {
-        return Optional.empty();
     }
 }

--- a/src/main/java/org/loadtest4j/drivers/wrk/dto/Latency.java
+++ b/src/main/java/org/loadtest4j/drivers/wrk/dto/Latency.java
@@ -3,14 +3,18 @@ package org.loadtest4j.drivers.wrk.dto;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-import java.util.Map;
+import java.math.BigDecimal;
+import java.util.TreeMap;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class Latency {
+    /**
+     * A mapping of (the percentile, decimal) to (the percentile value).
+     */
     @JsonProperty
-    private Map<Integer, Long> percentiles;
+    private TreeMap<BigDecimal, Long> percentiles;
 
-    public Map<Integer, Long> getPercentiles() {
+    public TreeMap<BigDecimal, Long> getPercentiles() {
         return percentiles;
     }
 }

--- a/src/main/java/org/loadtest4j/drivers/wrk/utils/Command.java
+++ b/src/main/java/org/loadtest4j/drivers/wrk/utils/Command.java
@@ -2,19 +2,26 @@ package org.loadtest4j.drivers.wrk.utils;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 public class Command {
 
     private final List<String> arguments;
+    private final Map<String, String> env;
     private final String launchPath;
 
-    public Command(List<String> arguments, String launchPath) {
+    public Command(List<String> arguments, Map<String, String> env, String launchPath) {
         this.arguments = arguments;
+        this.env = env;
         this.launchPath = launchPath;
     }
 
     public List<String> getArguments() {
         return Collections.unmodifiableList(arguments);
+    }
+
+    public Map<String, String> getEnv() {
+        return env;
     }
 
     public String getLaunchPath() {

--- a/src/main/java/org/loadtest4j/drivers/wrk/utils/FileUtils.java
+++ b/src/main/java/org/loadtest4j/drivers/wrk/utils/FileUtils.java
@@ -10,11 +10,16 @@ import java.nio.file.StandardCopyOption;
 
 public class FileUtils {
     public static Path createTempFile(String prefix, String suffix) {
+        final Path p;
         try {
-            return Files.createTempFile(prefix, suffix);
+            p = Files.createTempFile(prefix, suffix);
         } catch (IOException e) {
             throw new LoadTesterException(e);
         }
+
+        p.toFile().deleteOnExit();
+
+        return p;
     }
 
     public static void copy(InputStream content, Path target) {

--- a/src/main/java/org/loadtest4j/drivers/wrk/utils/Json.java
+++ b/src/main/java/org/loadtest4j/drivers/wrk/utils/Json.java
@@ -1,7 +1,6 @@
 package org.loadtest4j.drivers.wrk.utils;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.loadtest4j.LoadTesterException;
 
 import java.io.File;
 import java.io.IOException;
@@ -11,19 +10,11 @@ public class Json {
 
     private static final ObjectMapper MAPPER = new ObjectMapper();
 
-    public static void serialize(File resultFile, Object value) {
-        try {
-            MAPPER.writeValue(resultFile, value);
-        } catch (IOException e) {
-            throw new LoadTesterException(e);
-        }
+    public static void serialize(File resultFile, Object value) throws IOException {
+        MAPPER.writeValue(resultFile, value);
     }
 
-    public static <T> T parse(Reader src, Class<T> valueType) {
-        try {
-            return MAPPER.readValue(src, valueType);
-        } catch (IOException e) {
-            throw new LoadTesterException(e);
-        }
+    public static <T> T parse(Reader src, Class<T> valueType) throws IOException {
+        return MAPPER.readValue(src, valueType);
     }
 }

--- a/src/main/java/org/loadtest4j/drivers/wrk/utils/Shell.java
+++ b/src/main/java/org/loadtest4j/drivers/wrk/utils/Shell.java
@@ -13,8 +13,11 @@ public class Shell {
         cmd.add(command.getLaunchPath());
         cmd.addAll(command.getArguments());
 
+        final ProcessBuilder pb = new ProcessBuilder(cmd)
+                .redirectInput(ProcessBuilder.Redirect.PIPE);
+        pb.environment().putAll(command.getEnv());
         try {
-            return new org.loadtest4j.drivers.wrk.utils.Process(new ProcessBuilder(cmd).redirectInput(ProcessBuilder.Redirect.PIPE).start());
+            return new org.loadtest4j.drivers.wrk.utils.Process(pb.start());
         } catch (IOException e) {
             throw new LoadTesterException(e);
         }

--- a/src/main/resources/loadtest4j-wrk.lua
+++ b/src/main/resources/loadtest4j-wrk.lua
@@ -40,7 +40,8 @@ done = function(summary, latency, requests)
         }
     }
 
-    for p = 0, 99
+    local granularity = 0.1
+    for p = 0, 100 - granularity, granularity
     do
         json["latency"]["percentiles"][p] = latency:percentile(p)
     end

--- a/src/main/resources/loadtest4j-wrk.lua
+++ b/src/main/resources/loadtest4j-wrk.lua
@@ -40,15 +40,29 @@ done = function(summary, latency, requests)
         }
     }
 
-    local granularity = 0.1
-    for p = 0, 100 - granularity, granularity
+    -- WARNING: decimalPlaces has a connascence with granularity. If you change one you MUST change the other.
+    local granularity = 0.001
+    local decimalPlaces = 3
+
+    for p = 0, 100, granularity
     do
-        json["latency"]["percentiles"][p] = latency:percentile(p)
+        -- We must round to the desired decimal places to stop p losing accuracy (e.g. the p95.9 becomes p95.8999999999)
+        local roundedP = round(p, decimalPlaces)
+        json["latency"]["percentiles"][roundedP] = latency:percentile(roundedP)
     end
+
     -- p100 is not available so use max instead
     json["latency"]["percentiles"][100] = latency.max
 
     io.stderr:write(encodeJson(json))
+end
+
+-- From https://stackoverflow.com/a/37792884/1475135
+function round(x, n)
+    n = math.pow(10, n)
+    x = x * n
+    if x >= 0 then x = math.floor(x + 0.5) else x = math.ceil(x - 0.5) end
+    return x / n
 end
 
 function readFile(file)

--- a/src/main/resources/loadtest4j-wrk.lua
+++ b/src/main/resources/loadtest4j-wrk.lua
@@ -54,7 +54,18 @@ done = function(summary, latency, requests)
     -- p100 is not available so use max instead
     json["latency"]["percentiles"][100] = latency.max
 
-    io.stderr:write(encodeJson(json))
+    printReport(encodeJson(json))
+end
+
+function printReport(report)
+    local outputFile = os.getenv("WRK_OUTPUT")
+    if outputFile == nil then
+        io.stderr:write(report)
+    else
+        local fho, _ = io.open(outputFile, "w")
+        fho:write(report)
+        fho:close()
+    end
 end
 
 -- From https://stackoverflow.com/a/37792884/1475135

--- a/src/test/java/org/loadtest4j/drivers/wrk/WrkParserTest.java
+++ b/src/test/java/org/loadtest4j/drivers/wrk/WrkParserTest.java
@@ -2,7 +2,6 @@ package org.loadtest4j.drivers.wrk;
 
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-import org.loadtest4j.LoadTesterException;
 import org.loadtest4j.driver.DriverResult;
 import org.loadtest4j.drivers.wrk.junit.UnitTest;
 
@@ -59,7 +58,7 @@ public class WrkParserTest {
                 .hasOk(7);
     }
 
-    @Test(expected = LoadTesterException.class)
+    @Test(expected = RuntimeException.class)
     public void testInvalidReport() {
         driverResult("invalid.json");
     }

--- a/src/test/java/org/loadtest4j/drivers/wrk/WrkParserTest.java
+++ b/src/test/java/org/loadtest4j/drivers/wrk/WrkParserTest.java
@@ -33,8 +33,7 @@ public class WrkParserTest {
         assertThat(driverResult("report.json"))
                 .hasKo(0)
                 .hasOk(1143)
-                .hasResponseTimePercentile(73, Duration.ofMillis(1))
-                .hasNoReportUrl();
+                .hasResponseTimePercentile(73, Duration.ofMillis(1));
     }
 
     @Test

--- a/src/test/java/org/loadtest4j/drivers/wrk/WrkResponseTimeTest.java
+++ b/src/test/java/org/loadtest4j/drivers/wrk/WrkResponseTimeTest.java
@@ -30,26 +30,26 @@ public class WrkResponseTimeTest {
     }
 
     @Test
-    public void testGetDecimalPercentileAt5DecimalPlaces() {
-        final WrkResponseTime responseTime = new WrkResponseTime(mapOf(bd("50.50001"), 1000L));
+    public void testGetDecimalPercentileAt3DecimalPlaces() {
+        final WrkResponseTime responseTime = new WrkResponseTime(mapOf(bd("50.501"), 1000L));
 
-        assertThat(responseTime.getDoublePercentile(50.50001)).isEqualTo(Duration.ofMillis(1));
+        assertThat(responseTime.getDoublePercentile(50.501)).isEqualTo(Duration.ofMillis(1));
     }
 
     @Test
     public void testGetDecimalPercentileWithTrailingZeroes() {
-        final WrkResponseTime responseTime = new WrkResponseTime(mapOf(bd("50.5"), 1000L, bd("50.50001"), 3000L));
+        final WrkResponseTime responseTime = new WrkResponseTime(mapOf(bd("50.5"), 1000L, bd("50.501"), 3000L));
 
-        assertThat(responseTime.getDoublePercentile(50.50000)).isEqualTo(Duration.ofMillis(1));
+        assertThat(responseTime.getDoublePercentile(50.500)).isEqualTo(Duration.ofMillis(1));
     }
 
     @Test
-    public void testGetDecimalPercentileBeyond5DecimalPlacesFails() {
-        final WrkResponseTime responseTime = new WrkResponseTime(mapOf(bd("50.00000"), 1000L, bd("50.00001"), 3000L));
+    public void testGetDecimalPercentileBeyond3DecimalPlacesFails() {
+        final WrkResponseTime responseTime = new WrkResponseTime(mapOf(bd("50.000"), 1000L, bd("50.001"), 3000L));
 
         assertThatIllegalArgumentException()
                 .isThrownBy(() -> responseTime.getDoublePercentile(50.000005))
-                .withMessage("The Wrk driver only supports percentile queries up to 5 decimal places.");
+                .withMessage("The Wrk driver only supports percentile queries up to 3 decimal places.");
     }
 
     @Test
@@ -57,7 +57,7 @@ public class WrkResponseTimeTest {
         final WrkResponseTime responseTime = new WrkResponseTime(mapOf(bd("50.4"), 1000L, bd("50.6"), 3000L));
 
         assertThatIllegalArgumentException()
-                .isThrownBy(() -> responseTime.getDoublePercentile(50.40001))
+                .isThrownBy(() -> responseTime.getDoublePercentile(50.401))
                 .withMessage("The Wrk driver could not find a response time value for that percentile.");
     }
 

--- a/src/test/java/org/loadtest4j/drivers/wrk/WrkResponseTimeTest.java
+++ b/src/test/java/org/loadtest4j/drivers/wrk/WrkResponseTimeTest.java
@@ -48,7 +48,7 @@ public class WrkResponseTimeTest {
         final WrkResponseTime responseTime = new WrkResponseTime(mapOf(bd("50.000"), 1000L, bd("50.001"), 3000L));
 
         assertThatIllegalArgumentException()
-                .isThrownBy(() -> responseTime.getPercentile(50.000005))
+                .isThrownBy(() -> responseTime.getPercentile(50.0005))
                 .withMessage("The Wrk driver only supports percentile queries up to 3 decimal places.");
     }
 

--- a/src/test/java/org/loadtest4j/drivers/wrk/WrkResponseTimeTest.java
+++ b/src/test/java/org/loadtest4j/drivers/wrk/WrkResponseTimeTest.java
@@ -26,21 +26,21 @@ public class WrkResponseTimeTest {
     public void testGetDecimalPercentile() {
         final WrkResponseTime responseTime = new WrkResponseTime(mapOf(bd("50.5"), 1000L));
 
-        assertThat(responseTime.getDoublePercentile(50.5)).isEqualTo(Duration.ofMillis(1));
+        assertThat(responseTime.getPercentile(50.5)).isEqualTo(Duration.ofMillis(1));
     }
 
     @Test
     public void testGetDecimalPercentileAt3DecimalPlaces() {
         final WrkResponseTime responseTime = new WrkResponseTime(mapOf(bd("50.501"), 1000L));
 
-        assertThat(responseTime.getDoublePercentile(50.501)).isEqualTo(Duration.ofMillis(1));
+        assertThat(responseTime.getPercentile(50.501)).isEqualTo(Duration.ofMillis(1));
     }
 
     @Test
     public void testGetDecimalPercentileWithTrailingZeroes() {
         final WrkResponseTime responseTime = new WrkResponseTime(mapOf(bd("50.5"), 1000L, bd("50.501"), 3000L));
 
-        assertThat(responseTime.getDoublePercentile(50.500)).isEqualTo(Duration.ofMillis(1));
+        assertThat(responseTime.getPercentile(50.500)).isEqualTo(Duration.ofMillis(1));
     }
 
     @Test
@@ -48,7 +48,7 @@ public class WrkResponseTimeTest {
         final WrkResponseTime responseTime = new WrkResponseTime(mapOf(bd("50.000"), 1000L, bd("50.001"), 3000L));
 
         assertThatIllegalArgumentException()
-                .isThrownBy(() -> responseTime.getDoublePercentile(50.000005))
+                .isThrownBy(() -> responseTime.getPercentile(50.000005))
                 .withMessage("The Wrk driver only supports percentile queries up to 3 decimal places.");
     }
 
@@ -57,7 +57,7 @@ public class WrkResponseTimeTest {
         final WrkResponseTime responseTime = new WrkResponseTime(mapOf(bd("50.4"), 1000L, bd("50.6"), 3000L));
 
         assertThatIllegalArgumentException()
-                .isThrownBy(() -> responseTime.getDoublePercentile(50.401))
+                .isThrownBy(() -> responseTime.getPercentile(50.401))
                 .withMessage("The Wrk driver could not find a response time value for that percentile.");
     }
 

--- a/src/test/java/org/loadtest4j/drivers/wrk/WrkResponseTimeTest.java
+++ b/src/test/java/org/loadtest4j/drivers/wrk/WrkResponseTimeTest.java
@@ -5,53 +5,121 @@ import org.junit.experimental.categories.Category;
 import org.loadtest4j.driver.DriverResponseTime;
 import org.loadtest4j.drivers.wrk.junit.UnitTest;
 
+import java.math.BigDecimal;
 import java.time.Duration;
-import java.util.Collections;
+import java.util.TreeMap;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 
 @Category(UnitTest.class)
 public class WrkResponseTimeTest {
 
     @Test
     public void testGetPercentile() {
-        final DriverResponseTime responseTime = new WrkResponseTime(Collections.singletonMap(50, 1000L));
+        final DriverResponseTime responseTime = new WrkResponseTime(mapOf(bd("50"), 1000L));
 
         assertThat(responseTime.getPercentile(50)).isEqualTo(Duration.ofMillis(1));
     }
 
     @Test
+    public void testGetDecimalPercentile() {
+        final WrkResponseTime responseTime = new WrkResponseTime(mapOf(bd("50.5"), 1000L));
+
+        assertThat(responseTime.getDoublePercentile(50.5)).isEqualTo(Duration.ofMillis(1));
+    }
+
+    @Test
+    public void testGetDecimalPercentileAt5DecimalPlaces() {
+        final WrkResponseTime responseTime = new WrkResponseTime(mapOf(bd("50.50001"), 1000L));
+
+        assertThat(responseTime.getDoublePercentile(50.50001)).isEqualTo(Duration.ofMillis(1));
+    }
+
+    @Test
+    public void testGetDecimalPercentileWithTrailingZeroes() {
+        final WrkResponseTime responseTime = new WrkResponseTime(mapOf(bd("50.5"), 1000L, bd("50.50001"), 3000L));
+
+        assertThat(responseTime.getDoublePercentile(50.50000)).isEqualTo(Duration.ofMillis(1));
+    }
+
+    @Test
+    public void testGetDecimalPercentileBeyond5DecimalPlacesFails() {
+        final WrkResponseTime responseTime = new WrkResponseTime(mapOf(bd("50.00000"), 1000L, bd("50.00001"), 3000L));
+
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> responseTime.getDoublePercentile(50.000005))
+                .withMessage("The Wrk driver only supports percentile queries up to 5 decimal places.");
+    }
+
+    @Test
+    public void testGetMissingDecimalPercentileFails() {
+        final WrkResponseTime responseTime = new WrkResponseTime(mapOf(bd("50.4"), 1000L, bd("50.6"), 3000L));
+
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> responseTime.getDoublePercentile(50.40001))
+                .withMessage("The Wrk driver could not find a response time value for that percentile.");
+    }
+
+    @Test
     public void testGetMaxPercentile() {
-        final DriverResponseTime responseTime = new WrkResponseTime(Collections.singletonMap(100, 1000L));
+        final DriverResponseTime responseTime = new WrkResponseTime(mapOf(bd("100"), 1000L));
 
         assertThat(responseTime.getPercentile(100)).isEqualTo(Duration.ofMillis(1));
     }
 
     @Test
     public void testGetMinPercentile() {
-        final DriverResponseTime responseTime = new WrkResponseTime(Collections.singletonMap(0, 1000L));
+        final DriverResponseTime responseTime = new WrkResponseTime(mapOf(bd("0"), 1000L));
 
         assertThat(responseTime.getPercentile(0)).isEqualTo(Duration.ofMillis(1));
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void testGetTooLowPercentile() {
-        final DriverResponseTime responseTime = new WrkResponseTime(Collections.singletonMap(-1, 1000L));
+    @Test
+    public void testGetTooLowPercentileFails() {
+        final DriverResponseTime responseTime = new WrkResponseTime(mapOf(bd("-1"), 1000L));
 
-        responseTime.getPercentile(-1);
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> responseTime.getPercentile(-1))
+                .withMessage("A percentile must be between 0 and 100");
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void testGetTooHighPercentile() {
-        final DriverResponseTime responseTime = new WrkResponseTime(Collections.singletonMap(101, 1000L));
+    @Test
+    public void testGetTooHighPercentileFails() {
+        final DriverResponseTime responseTime = new WrkResponseTime(mapOf(bd("101"), 1000L));
 
-        responseTime.getPercentile(-1);
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> responseTime.getPercentile(101))
+                .withMessage("A percentile must be between 0 and 100");
     }
 
-    @Test(expected = NullPointerException.class)
-    public void testGetMissingPercentile() {
-        final DriverResponseTime responseTime = new WrkResponseTime(Collections.emptyMap());
+    @Test
+    public void testGetMissingPercentileFails() {
+        final DriverResponseTime responseTime = new WrkResponseTime(emptyMap());
 
-        responseTime.getPercentile(50);
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> responseTime.getPercentile(50))
+                .withMessage("The Wrk driver could not find a response time value for that percentile.");
+    }
+
+    private static BigDecimal bd(String d) {
+        return new BigDecimal(d);
+    }
+
+    private static <K, V> TreeMap<K, V> emptyMap() {
+        return new TreeMap<>();
+    }
+
+    private static <K, V> TreeMap<K, V> mapOf(K k1, V v1) {
+        final TreeMap<K, V> m = new TreeMap<>();
+        m.put(k1, v1);
+        return m;
+    }
+
+    private static <K, V> TreeMap<K, V> mapOf(K k1, V v1, K k2, V v2) {
+        final TreeMap<K, V> m = new TreeMap<>();
+        m.put(k1, v1);
+        m.put(k2, v2);
+        return m;
     }
 }

--- a/src/test/java/org/loadtest4j/drivers/wrk/WrkTest.java
+++ b/src/test/java/org/loadtest4j/drivers/wrk/WrkTest.java
@@ -75,7 +75,6 @@ public class WrkTest {
         DriverResultAssert.assertThat(result)
                 .hasOkGreaterThan(0)
                 .hasKo(0)
-                .hasNoReportUrl()
                 .hasActualDurationGreaterThan(EXPECTED_DURATION)
                 .hasMaxResponseTimeGreaterThan(Duration.ZERO);
     }

--- a/src/test/java/org/loadtest4j/drivers/wrk/WrkTest.java
+++ b/src/test/java/org/loadtest4j/drivers/wrk/WrkTest.java
@@ -185,7 +185,7 @@ public class WrkTest {
     }
 
     @Test
-    public void testRunWithBrokenDriver() {
+    public void testRunWithInvalidHost() {
         // Given
         final Driver driver = new Wrk(1, EXPECTED_DURATION, "wrk", 1, "http://localhost:1");
 

--- a/src/test/java/org/loadtest4j/drivers/wrk/WrkTest.java
+++ b/src/test/java/org/loadtest4j/drivers/wrk/WrkTest.java
@@ -29,7 +29,7 @@ import static com.xebialabs.restito.semantics.Condition.*;
 @Category(IntegrationTest.class)
 public class WrkTest {
 
-    private static final Duration EXPECTED_DURATION = Duration.ofSeconds(1);
+    private static final Duration EXPECTED_DURATION = Duration.ofSeconds(2);
 
     private StubServer httpServer;
 

--- a/src/test/java/org/loadtest4j/drivers/wrk/junit/DriverResultAssert.java
+++ b/src/test/java/org/loadtest4j/drivers/wrk/junit/DriverResultAssert.java
@@ -76,16 +76,6 @@ public class DriverResultAssert extends AbstractAssert<DriverResultAssert, Drive
         return this;
     }
 
-    public DriverResultAssert hasNoReportUrl() {
-        isNotNull();
-
-        actual.getReportUrl().ifPresent(url -> {
-            failWithMessage("Expected report URL to be absent but was <%s>", url);
-        });
-
-        return this;
-    }
-
     public DriverResultAssert hasResponseTimePercentile(int percentile, Duration responseTime) {
         isNotNull();
 

--- a/src/test/java/org/loadtest4j/drivers/wrk/utils/CommandTest.java
+++ b/src/test/java/org/loadtest4j/drivers/wrk/utils/CommandTest.java
@@ -5,12 +5,13 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
 import java.util.Arrays;
+import java.util.Collections;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 @Category(UnitTest.class)
 public class CommandTest {
-    private final Command command = new Command(Arrays.asList("foo", "bar"), "whoami");
+    private final Command command = new Command(Arrays.asList("foo", "bar"), Collections.singletonMap("foo", "bar"), "whoami");
 
     @Test
     public void testGetLaunchPath() {
@@ -20,5 +21,10 @@ public class CommandTest {
     @Test
     public void testGetArguments() {
         assertThat(command.getArguments()).containsExactly("foo", "bar");
+    }
+
+    @Test
+    public void testGetEnv() {
+        assertThat(command.getEnv()).containsEntry("foo", "bar");
     }
 }

--- a/src/test/java/org/loadtest4j/drivers/wrk/utils/JsonTest.java
+++ b/src/test/java/org/loadtest4j/drivers/wrk/utils/JsonTest.java
@@ -3,13 +3,9 @@ package org.loadtest4j.drivers.wrk.utils;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-import org.loadtest4j.LoadTesterException;
 import org.loadtest4j.drivers.wrk.junit.IntegrationTest;
 
-import java.io.File;
-import java.io.FileReader;
-import java.io.InputStreamReader;
-import java.io.Reader;
+import java.io.*;
 import java.nio.charset.StandardCharsets;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -27,7 +23,7 @@ public class JsonTest {
     }
 
     @Test
-    public void testRoundTrip() throws Exception {
+    public void testRoundTrip() throws IOException {
         final Foo input = new Foo();
         input.a = "b";
 
@@ -40,15 +36,15 @@ public class JsonTest {
         assertThat(output.a).isEqualTo(input.a);
     }
 
-    @Test(expected = LoadTesterException.class)
-    public void testParseError() throws Exception {
+    @Test(expected = IOException.class)
+    public void testParseError() throws IOException {
         try (Reader reader = json("invalid.json")) {
             Json.parse(reader, Foo.class);
         }
     }
 
-    @Test(expected = LoadTesterException.class)
-    public void testSerializeError() {
+    @Test(expected = IOException.class)
+    public void testSerializeError() throws IOException {
         final Foo foo = new Foo();
 
         File file = FileUtils.createTempFile("foo", ".json").toFile();

--- a/src/test/java/org/loadtest4j/drivers/wrk/utils/ShellTest.java
+++ b/src/test/java/org/loadtest4j/drivers/wrk/utils/ShellTest.java
@@ -14,7 +14,7 @@ public class ShellTest {
     public void testWaitFor() {
         final Shell sut = new Shell();
 
-        final Command command = new Command(Collections.emptyList(), "whoami");
+        final Command command = new Command(Collections.emptyList(), Collections.emptyMap(), "whoami");
         final int exitStatus = sut.start(command).waitFor();
 
         assertThat(exitStatus).isEqualTo(0);


### PR DESCRIPTION
Support response time queries for sub-integer percentiles. I.e. "what is the 99.999th percentile response time?"

Fixes #39 